### PR TITLE
Add ability to retrieve a single post by id

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,11 @@ You can collect the "top posts" of the day, week, month, or year:
     garc top yearly
 
 This will return the top 15 or so posts that day.
+
+### Statuses
+
+You can retrieve a single post by its ID:
+
+	garc statuses 106525740881070143
+	
+This will return Andrew Torba's current pinned Gab. 

--- a/garc/client.py
+++ b/garc/client.py
@@ -163,6 +163,10 @@ class Garc(object):
         resp = self.anonymous_get(url)
         return resp.json()
 
+    def statuses(self, q):
+        url = "https://gab.com/api/v1/statuses/%s" % (q)
+        resp = self.get(url)
+        yield resp.json()
 
     def userposts(self, q, gabs=-1, gabs_after='2000-01-01'):
         """

--- a/garc/command.py
+++ b/garc/command.py
@@ -26,6 +26,7 @@ commands = [
     'user',
     'userposts',
     'usercomments',
+    'statuses',
     'top'
 ]
 
@@ -101,6 +102,8 @@ def main():
         )
     elif command == 'top':
         things = g.top(timespan=query if query else None)
+    elif command == 'statuses':
+        things = g.statuses(query)
 
     else:
         parser.print_help()


### PR DESCRIPTION
This pull request adds the 'statuses' command which allows a single Gab to be retrieved by post ID. 