### PR TITLE
persist cookies to file, commands for working with groups

### DIFF
--- a/garc/client.py
+++ b/garc/client.py
@@ -156,6 +156,40 @@ class Garc(object):
         resp = self.get(url)
         yield resp.json()
 
+    def group(self, q):
+        """
+        collect group json data
+        q should be the group ID
+        """
+        url = 'https://gab.com/api/v1/groups/%s' % (q)
+        resp = self.get(url)
+        yield resp.json()
+
+    def groupposts(self, q, gabs=-1, gabs_after='2000-01-01'):
+        """
+        collect posts from a group feed
+        q should be the group ID
+        """
+        base_url = 'https://gab.com/api/v1/timelines/group/%s?sort_by=newest&page=' % (q)
+        page = 1
+        num_gabs = 0
+        while True:
+            url = base_url + str(page)
+            page += 1
+            resp = self.get(url)
+            posts = resp.json()
+            if not posts:
+                break
+            last_published_date = posts[-1]['created_at']
+            for post in posts:
+                yield self.format_post(post)
+            num_gabs += len(posts)
+            if last_published_date < gabs_after:
+                break
+            if (num_gabs > gabs and gabs != -1):
+                break
+
+
     def top(self, timespan=None):
         if timespan is None: timespan = "today"
         assert timespan in ["today", "weekly", "monthly", "yearly"]

--- a/garc/command.py
+++ b/garc/command.py
@@ -26,7 +26,9 @@ commands = [
     'user',
     'userposts',
     'usercomments',
-    'top'
+    'top',
+    'group',
+    'groupposts',
 ]
 
 
@@ -81,7 +83,10 @@ def main():
         sys.exit()
     elif command == 'user':
         things = g.user(query)
-
+    elif command == 'group':
+        things = g.group(query)
+    elif command == 'groupposts':
+        things = g.groupposts(query)
     elif command == 'userposts':
         things = g.userposts(
             query,

--- a/garc/command.py
+++ b/garc/command.py
@@ -86,7 +86,11 @@ def main():
     elif command == 'group':
         things = g.group(query)
     elif command == 'groupposts':
-        things = g.groupposts(query)
+        things = g.groupposts(
+            query,
+            gabs=args.number_gabs,
+            gabs_after=args.gabs_after
+        )
     elif command == 'userposts':
         things = g.userposts(
             query,


### PR DESCRIPTION
Hi Chris!

Thanks for making this open source. Currently, garc will trigger a login each time it's run. If garc is run frequently, requests to https://gab.com/auth/sign_in can trigger Cloudflare's browser check, preventing the login. This commit will make it so that garc saves cookies after login to a file, in Netscape format. The file will be located adjacent to the config file (~/.garc by default), with the extension _cookies.txt (so ~/.garc_cookies.txt by default). The cookies file would then be used on the next run. As an added benefit, a user could use an extension like https://chrome.google.com/webstore/detail/get-cookiestxt/bgaddhkoddajcdgocldbbfleckgcbcid?hl=en to export their cookies from their browser and use those.

Take a look and let me know what you think